### PR TITLE
Add Rectangles to Make Text Visible

### DIFF
--- a/assets/javascripts/radar.js
+++ b/assets/javascripts/radar.js
@@ -24,7 +24,7 @@ function createVulnerabilityMap(data) {
 
   textTangle = textTriangleGroup
     .append('rect')
-    .attr('width', 430)
+    .attr('width', 450)
     .attr('height', 100)
     .style('stroke-width', 0)
     .style('stroke', 'rgb(0,0,0)')
@@ -41,7 +41,7 @@ function createVulnerabilityMap(data) {
     .attr('dy', '1.2em')
     .style('font-size', '1.5rem')
     .style('font-weight', '600')
-    .style('font-family', 'Calibre')
+    .style('font-family', 'CalibreWeb-Semibold')
     .style('color', '#101436')
     .text('Vulnerability Map')
 
@@ -50,7 +50,7 @@ function createVulnerabilityMap(data) {
     .attr('dy', '1.2em')
     .attr('text-anchor', 'left')
     .style('font-size', '1.875rem')
-    .style('font-family', 'Swift Neue LT Pro')
+    .style('font-family', 'SwiftNeueLTPro')
     .style('color', '#101436')
     .text('Boston Harbor Flood Risk Model')
 
@@ -68,7 +68,6 @@ function createVulnerabilityMap(data) {
     .attr('x', 0)
     .attr('y', 0)
 
-
   textTangle = legendGroup
     .append('rect')
     .attr('x', 680)
@@ -78,7 +77,6 @@ function createVulnerabilityMap(data) {
     .style('stroke-width', 0)
     .style('stroke', 'rgb(0,0,0)')
     .style('fill', 'rgb(255,255,255,.5)')
-
 
   const keys = ['Extremely low', 'Moderately low', 'Moderate', 'Moderately high', 'Extremely high']
 

--- a/assets/javascripts/radar.js
+++ b/assets/javascripts/radar.js
@@ -19,13 +19,24 @@ function createVulnerabilityMap(data) {
     .attr('d', path)
     .on('click', data => updateCharts(data) )
 
-  textBox = d3.select('.climate-map')
+  textTriangleGroup = d3.select('.climate-map')
+    .append('g')
+
+  textTangle = textTriangleGroup
+    .append('rect')
+    .attr('width', 430)
+    .attr('height', 100)
+    .style('stroke-width', 0)
+    .style('stroke', 'rgb(0,0,0)')
+    .style('fill', 'rgb(255,255,255,.5)')
+
+  textBox = textTriangleGroup
     .append('text')
     .attr('x', 0)
     .attr('y', 0)
 
   textBox.append('tspan')
-    .attr('x', 0)
+    .attr('x', 10)
     .attr('text-anchor', 'left')
     .attr('dy', '1.2em')
     .style('font-size', '1.5rem')
@@ -35,7 +46,7 @@ function createVulnerabilityMap(data) {
     .text('Vulnerability Map')
 
   textBox.append('tspan')
-    .attr('x', 0)
+    .attr('x', 10)
     .attr('dy', '1.2em')
     .attr('text-anchor', 'left')
     .style('font-size', '1.875rem')
@@ -44,16 +55,34 @@ function createVulnerabilityMap(data) {
     .text('Boston Harbor Flood Risk Model')
 
   textBox.append('tspan')
-    .attr('x', 0)
+    .attr('x', 10)
     .attr('dy', '1.5em')
     .attr('text-anchor', 'left')
     .style('font-size', '.75rem')
     .style('color', '#101436')
-    .text('Source: BH-FRM, MassDOT, Woods Hole Group, UMass Boston, UNH')
+    .text('Sources available in technical publication.')
+
+
+  legendGroup = d3.select('.climate-map')
+    .append('g')
+    .attr('x', 0)
+    .attr('y', 0)
+
+
+  textTangle = legendGroup
+    .append('rect')
+    .attr('x', 680)
+    .attr('y', 280)
+    .attr('width', 150)
+    .attr('height', 140)
+    .style('stroke-width', 0)
+    .style('stroke', 'rgb(0,0,0)')
+    .style('fill', 'rgb(255,255,255,.5)')
+
 
   const keys = ['Extremely low', 'Moderately low', 'Moderate', 'Moderately high', 'Extremely high']
 
-  d3.select('.climate-map')
+  legendGroup
     .selectAll('legend')
     .data(keys)
     .enter()


### PR DESCRIPTION
This commit adds rectangles behind our SVG text elements so that they are still visible when zooming the map in and out.