### PR TITLE
Add Mobile Margin to Links

### DIFF
--- a/_sass/index.scss
+++ b/_sass/index.scss
@@ -71,7 +71,7 @@ body {
     text-align: left;
     color: $color_navy_text;
     font-family: $font_family-primary;
-    
+
     &--italics {
       font-style: italic;
     }
@@ -399,6 +399,10 @@ body {
 .links {
   align-items: center;
   margin-bottom: 8.875rem;
+
+  @media only screen and (max-width: 1200px) {
+    margin: 2rem;
+  }
 
   &__item {
     align-items: center;


### PR DESCRIPTION
In order to not have the link images hanging at the edge of the screen this adds some margin to the left and right of the links. It also reduces the vertical margin to reduce scrolling on mobile.